### PR TITLE
Refactor images to allow for more images with organization

### DIFF
--- a/.github/workflows/usb-image.yml
+++ b/.github/workflows/usb-image.yml
@@ -5,6 +5,8 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+    paths:
+      - images/usb-image/**
   pull_request:
     branches:
       - main
@@ -28,7 +30,7 @@ jobs:
         run: docker login --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" ghcr.io
 
       - name: "Build USB Container Image"
-        run: earthly +usb-image
+        run: earthly ./images/usb-image/+image
         env:
           EARTHLY_CI: true
           EARTHLY_PUSH: ${{ github.event_name != 'pull_request' }}

--- a/Earthfile
+++ b/Earthfile
@@ -26,16 +26,5 @@ prettier-lint:
 lint:
     BUILD +prettier-lint
 
-usb-image:
-    ARG tag='latest'
-    FROM alpine
-
-    RUN mkdir -p /usr/lib/extension-release.d/
-    RUN echo ID=_any > /usr/lib/extension-release.d/extension-release.kubo
-    SAVE ARTIFACT /usr/lib/extension-release.d
-    SAVE ARTIFACT /usr/bin/lsusb
-    SAVE ARTIFACT /usr/bin/less
-    SAVE IMAGE --push ghcr.io/marinatedconcrete/usb-image:$tag
-
 images:
-    BUILD +usb-image
+    BUILD ./images+all

--- a/images/Earthfile
+++ b/images/Earthfile
@@ -1,0 +1,5 @@
+VERSION 0.7
+FROM alpine
+
+all:
+    BUILD ./usb-image/+image

--- a/images/usb-image/Earthfile
+++ b/images/usb-image/Earthfile
@@ -1,0 +1,14 @@
+VERSION 0.7
+FROM alpine
+
+image:
+    ARG tag='latest'
+    FROM alpine
+
+    RUN mkdir -p /usr/lib/extension-release.d/
+    RUN echo ID=_any > /usr/lib/extension-release.d/extension-release.kubo
+    SAVE ARTIFACT /usr/lib/extension-release.d
+    SAVE ARTIFACT /usr/bin/lsusb
+    SAVE ARTIFACT /usr/bin/less
+    SAVE IMAGE --push ghcr.io/marinatedconcrete/usb-image:$tag
+


### PR DESCRIPTION
This adds a new images directory, and moves the usb-image build into its own `Earthfile`.  This will give us more structure to add additional images over time.