### PR TITLE
Add option to write corrected prettier output back to repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "Ubuntu",
+  "image": "buildpack-deps:22.04-curl",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "installOhMyZsh": false,
+      "installOhMyZshConfig": false
+    },
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "latest",
+      "helm": "none",
+      "minikube": "none"
+    },
+    "ghcr.io/earthly/devcontainer-features/earthly:1": { "bootstrap": true },
+    "ghcr.io/marinatedconcrete/config/ansible:1.2.0": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["earthly.earthfile-syntax-highlighting"]
+    }
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "EARTHLY_ORG": "marinatedconcrete",
+    "EARTHLY_SATELLITE": "config-repo"
+  }
+}

--- a/Earthfile
+++ b/Earthfile
@@ -31,7 +31,13 @@ prettier-lint:
     RUN yarn
     COPY . .
     COPY --dir .prettierignore .prettierrc.yml .github .
-    RUN yarn check-format
+    ARG write=false
+    IF [ "$write" = "true" ]
+      RUN yarn format
+      SAVE ARTIFACT /config/* AS LOCAL .
+    ELSE
+      RUN yarn check-format || echo "Lint failed. Please re-run earthly with --write=true to save the corrections"
+    END
 
 shellcheck-lint:
     # renovate: datasource=docker depName=koalaman/shellcheck-alpine versioning=docker


### PR DESCRIPTION
Fixes #46 

You can run `earthly +lint --write=true` to have it autoformat for you. This will let us migrate to faster tools in the future.