### PR TITLE
Support preserving Earthly configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,8 +25,10 @@
     }
   },
   "remoteUser": "vscode",
+  "mounts": [
+    "source=${localEnv:HOME}/.earthly,target=/home/vscode/.earthly,type=bind,consistency=cached"
+  ],
   "containerEnv": {
-    "EARTHLY_ORG": "marinatedconcrete",
     "EARTHLY_SATELLITE": "config-repo"
   }
 }


### PR DESCRIPTION
This mounts the `.earthly` directory from the user's homedir so that any configuration (like login or org) persists between devcontainer instances.