### PR TITLE
Revert "Update earthly/earthly Docker tag to v0.7.23 (#90)"

### DIFF
--- a/.github/workflows/kairos-ubuntu-22-lts.yml
+++ b/.github/workflows/kairos-ubuntu-22-lts.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # renovate: datasource=docker depName=earthly/earthly
-          version: "v0.7.23"
+          version: "v0.7.22"
       - uses: actions/checkout@v4.1.1
       - uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/kairos-zsh-bundle.yml
+++ b/.github/workflows/kairos-zsh-bundle.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # renovate: datasource=docker depName=earthly/earthly
-          version: "v0.7.23"
+          version: "v0.7.22"
       - uses: "actions/checkout@v4.1.1"
 
       - name: "Login to GitHub Container Hub"

--- a/.github/workflows/kustomization-tests.yml
+++ b/.github/workflows/kustomization-tests.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # renovate: datasource=docker depName=earthly/earthly
-          version: "v0.7.23"
+          version: "v0.7.22"
       - uses: actions/checkout@v4.1.1
 
       - name: Build Image

--- a/.github/workflows/usb-image.yml
+++ b/.github/workflows/usb-image.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # renovate: datasource=docker depName=earthly/earthly
-          version: "v0.7.23"
+          version: "v0.7.22"
       - uses: "actions/checkout@v4.1.1"
 
       - name: "Login to GitHub Container Hub"

--- a/earthly.sh
+++ b/earthly.sh
@@ -7,6 +7,6 @@ docker run \
     -t \
     -v "$(pwd)":/workspace \
     -v earthly-tmp:/tmp/earthly:rw \
-    earthly/earthly:v0.7.23 \
+    earthly/earthly:v0.7.22 \
     --allow-privileged \
     "$@"


### PR DESCRIPTION
This reverts commit 078a52289efc9708e4eba55fedb23782d584b7f1. We suspect this is causing CI failures.
