### PR TITLE
Add more ansible files to the kustomize test paths

### DIFF
--- a/.github/workflows/kustomization-tests.yml
+++ b/.github/workflows/kustomization-tests.yml
@@ -7,6 +7,8 @@ on: # yamllint disable-line rule:truthy
       - main
     paths:
       - .github/workflows/kustomization-tests.yml
+      - ansible/Earthfile
+      - ansible/galaxy.yml
       - ansible/playbooks/kustomization_test.yml
       - ansible/roles/minikube_test/**
       - kustomization/tests/**
@@ -15,6 +17,8 @@ on: # yamllint disable-line rule:truthy
       - main
     paths:
       - .github/workflows/kustomization-tests.yml
+      - ansible/Earthfile
+      - ansible/galaxy.yml
       - ansible/playbooks/kustomization_test.yml
       - ansible/roles/minikube_test/**
       - kustomization/tests/**


### PR DESCRIPTION
Should ensure that PRs like #86 don't break these tests
