### PR TITLE
Put the image metadata into the OS release

### DIFF
--- a/images/kairos-ubuntu-22-lts/Earthfile
+++ b/images/kairos-ubuntu-22-lts/Earthfile
@@ -73,4 +73,5 @@ push-generic:
     ARG UBUNTU_VERSION
     ARG TAG
     FROM +image-generic --PLATFORM=$PLATFORM --DEVICE=$DEVICE --UBUNTU_VERSION=$UBUNTU_VERSION
+    RUN echo "MARINATEDCONCRETE_IMAGE=ghcr.io/marinatedconcrete/kairos-ubuntu-22-lts:$TAG" >> /etc/os-release
     SAVE IMAGE --push ghcr.io/marinatedconcrete/kairos-ubuntu-22-lts:$TAG


### PR DESCRIPTION
This is something we can easily diff against in our upgrade script to know when there's an upgrade. I left the Kairos variables alone because a) they reflect what Kairos version this is built off of, and b) they might affect other parts of the system that we're not aware of. This seems consistent with the [Customizing the system image section of the Kairos docs](https://kairos.io/docs/advanced/customizing/) which shows adding a new variable to this file to reflect the customized version.