### PR TITLE
Enable renovate to automerge all patch level updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,13 @@
       "matchPackageNames": ["prettier", "yarn"],
       "automerge": true,
       "automergeSchedule": ["every day"]
+    },
+    {
+      "description": "Auto-merge all patch updates - they have been safe so far",
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
I have a similar rule for my repo and this helps keep the PR noise down. All the checks will continue to run I believe, and the 3 day waiting period helps de-risk including bugs that are quickly discovered by the community. We could go longer than 3 days.
