### PR TITLE
Upgrade debian to bookworm

### DIFF
--- a/ansible/Earthfile
+++ b/ansible/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
 # renovate: datasource=docker depName=python versioning=docker
-ARG PYTHON_VERSION=3.12.4-bullseye
+ARG PYTHON_VERSION=3.12.4-bookworm
 FROM python:$PYTHON_VERSION
 
 WORKDIR /ansible

--- a/images/universal-silabs-flasher/Earthfile
+++ b/images/universal-silabs-flasher/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
 # renovate: datasource=docker depName=python versioning=docker
-ARG PYTHON_VERSION=3.12.4-bullseye
+ARG PYTHON_VERSION=3.12.4-bookworm
 FROM python:$PYTHON_VERSION
 
 image:


### PR DESCRIPTION
It's been out for about a year. Bullseye is about 3 years old and is hitting a support milestone soon.

https://en.wikipedia.org/wiki/Debian_version_history
