### PR TITLE
Greatly improve testing of the unifi-network-application component

### DIFF
--- a/ansible/roles/minikube_test/defaults/main.yml
+++ b/ansible/roles/minikube_test/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 # defaults file for minikube_test
 
+# If the test harness should enable local path storage.  See
+# https://minikube.sigs.k8s.io/docs/tutorials/local_path_provisioner/
+minikube_test__enable_local_path_storage: false
+
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 minikube_test__kubernetes_version: v1.28.3
 

--- a/ansible/roles/minikube_test/tasks/main.yml
+++ b/ansible/roles/minikube_test/tasks/main.yml
@@ -11,6 +11,27 @@
       - --force
   changed_when: true
   notify: stop minikube
+- name: Setup local path provisioner
+  when: minikube_test__enable_local_path_storage | bool
+  block:
+    - name: Enable local path provisioner
+      ansible.builtin.command:
+        argv:
+          - minikube
+          - "--profile={{ kubernetes_core_k8s__context | default(minikube_test__test_name) }}"
+          - addons
+          - enable
+          - storage-provisioner-rancher
+      changed_when: true
+    - name: Wait for provisioner deployment
+      kubernetes.core.k8s:
+        api_version: apps/v1
+        context: "{{ kubernetes_core_k8s__context | default(minikube_test__test_name) }}"
+        kind: Deployment
+        name: local-path-provisioner
+        namespace: local-path-storage
+        state: present
+        wait: true
 - name: Apply kustomization
   kubernetes.core.k8s:
     apply: true

--- a/ansible/roles/minikube_test/tasks/main.yml
+++ b/ansible/roles/minikube_test/tasks/main.yml
@@ -6,7 +6,7 @@
       - minikube
       - start
       - --interactive=false
-      - "--profile={{ minikube_test__test_name }}"
+      - "--profile={{ kubernetes_core_k8s__context | default(minikube_test__test_name) }}"
       - "--kubernetes-version={{ minikube_test__kubernetes_version }}"
       - --force
   changed_when: true
@@ -14,5 +14,5 @@
 - name: Apply kustomization
   kubernetes.core.k8s:
     apply: true
-    context: "{{ minikube_test__test_name }}"
+    context: "{{ kubernetes_core_k8s__context | default(minikube_test__test_name) }}"
     definition: "{{ lookup('kubernetes.core.kustomize', dir=minikube_test__test_dir) }}"

--- a/justfile
+++ b/justfile
@@ -75,9 +75,11 @@ lint: ansible-lint hado-lint kustomize-lint renovate-lint shellcheck-lint
 kustomization-tests:
     #!/usr/bin/env bash
     set -euo pipefail
-    find kustomization/tests -mindepth 1 -maxdepth 1 -type d -print | \
-        awk '{print "minikube_test__test_dir="$1}' | \
-        xargs -r -n1 ansible-playbook marinatedconcrete.config.kustomization_test -e
+    find kustomization/tests/*/test.yml -print | while read -r file; do
+        echo -n "Running tests in ${file}..."
+        ansible-playbook ${file}
+        echo "{{ BOLD + GREEN }}OK{{ NORMAL }}"
+    done
 
 # Run all tests
 [group('test')]

--- a/kustomization/components/unifi-network-application/kustomization.yml
+++ b/kustomization/components/unifi-network-application/kustomization.yml
@@ -9,11 +9,11 @@ configMapGenerator:
       - configmap/shutdown-mongo.js
 images:
   - name: busybox
-    newTag: 1.37.0
+    newTag: 1.37.0@sha256:a5d0ce49aa801d475da48f8cb163c354ab95cab073cd3c138bd458fc8257fbf1
   - name: lscr.io/linuxserver/unifi-network-application
-    newTag: 9.0.114
+    newTag: 9.0.114@sha256:8990fe661fc5b4677d38eaf1321012f2a4322d965540051db8104d6a8329952b
   - name: mongo
-    newTag: 7.0.16
+    newTag: 7.0.16@sha256:e557aa97915d4d0ca4fb9ecf90e55dc4006faa973c7718c1529df325c64342ad
 resources:
   - statefulset.yml
   - serverstransport.yml

--- a/kustomization/tests/kube-vip/test.yml
+++ b/kustomization/tests/kube-vip/test.yml
@@ -1,0 +1,8 @@
+---
+- name: Kube-vip Tests
+  gather_facts: false
+  hosts: localhost
+  roles:
+    - role: marinatedconcrete.config.minikube_test
+      vars:
+        minikube_test__test_dir: kustomization/tests/kube-vip

--- a/kustomization/tests/mosquitto/test.yml
+++ b/kustomization/tests/mosquitto/test.yml
@@ -1,0 +1,8 @@
+---
+- name: Mosquitto Tests
+  gather_facts: false
+  hosts: localhost
+  roles:
+    - role: marinatedconcrete.config.minikube_test
+      vars:
+        minikube_test__test_dir: kustomization/tests/mosquitto

--- a/kustomization/tests/paperless/test.yml
+++ b/kustomization/tests/paperless/test.yml
@@ -1,0 +1,8 @@
+---
+- name: Paperless Tests
+  gather_facts: false
+  hosts: localhost
+  roles:
+    - role: marinatedconcrete.config.minikube_test
+      vars:
+        minikube_test__test_dir: kustomization/tests/paperless

--- a/kustomization/tests/priorityclass/test.yml
+++ b/kustomization/tests/priorityclass/test.yml
@@ -1,0 +1,8 @@
+---
+- name: Unifi Network Appliance Tests
+  gather_facts: false
+  hosts: localhost
+  roles:
+    - role: marinatedconcrete.config.minikube_test
+      vars:
+        minikube_test__test_dir: kustomization/tests/priorityclass

--- a/kustomization/tests/unifi-network-application/kustomization.yml
+++ b/kustomization/tests/unifi-network-application/kustomization.yml
@@ -16,5 +16,32 @@ patches:
         name: this-is-ignored-but-is-required
     target:
       kind: ServersTransport
+  # Change storage class so we use minikube's local path provisioner.
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: unifi-network-application-statefulset
+      spec:
+        volumeClaimTemplates:
+          - metadata:
+              name: mongodb-data
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+              storageClassName: local-path
+          - metadata:
+              name: unifi-config
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+              storageClassName: local-path
 resources:
   - namespace.yml
+  - secret.yml

--- a/kustomization/tests/unifi-network-application/secret.yml
+++ b/kustomization/tests/unifi-network-application/secret.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: una-secret
+stringData:
+  MONGO_PASS: super-secure

--- a/kustomization/tests/unifi-network-application/test.yml
+++ b/kustomization/tests/unifi-network-application/test.yml
@@ -5,4 +5,33 @@
   roles:
     - role: marinatedconcrete.config.minikube_test
       vars:
+        minikube_test__enable_local_path_storage: true
         minikube_test__test_dir: kustomization/tests/unifi-network-application
+  tasks:
+    - name: Wait for statefulset
+      kubernetes.core.k8s:
+        api_version: apps/v1
+        context: "{{ kubernetes_core_k8s__context }}"
+        kind: StatefulSet
+        name: unifi-network-application-statefulset
+        namespace: "{{ test_namespace }}"
+        state: present
+        wait: true
+        wait_timeout: 300 # Five minutes
+      changed_when: false
+    - name: Get endpoints information
+      kubernetes.core.k8s_info:
+        api_version: v1
+        context: "{{ kubernetes_core_k8s__context }}"
+        kind: Endpoints
+        name: unifi-network-application-svc
+        namespace: "{{ test_namespace }}"
+      register: endpoints
+    - name: Ensure the endpoint was in a good state
+      ansible.builtin.assert:
+        that:
+          - endpoints.resources | length | bool # Found
+          - (endpoints.resources | first).subsets | length | bool
+  vars:
+    kubernetes_core_k8s__context: unifi-network-application
+    test_namespace: "{{ (lookup('file', 'namespace.yml') | from_yaml).metadata.name }}"

--- a/kustomization/tests/unifi-network-application/test.yml
+++ b/kustomization/tests/unifi-network-application/test.yml
@@ -1,0 +1,8 @@
+---
+- name: Unifi Network Appliance Tests
+  gather_facts: false
+  hosts: localhost
+  roles:
+    - role: marinatedconcrete.config.minikube_test
+      vars:
+        minikube_test__test_dir: kustomization/tests/unifi-network-application


### PR DESCRIPTION
This does a few things (broken out into different commits):
- pin all containers used by the component
- adds the ability for each component to define custom tests
- adds the ability to have local storage provisioning in tests
- asserts that the unifi stateful set comes up
- asserts that the unifi service has endpoints that are subsets