### PR TITLE
feat: Create a new shareable Renovate config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "ansible": "0.1.0",
   "kustomization/components/priorityclass": "1.0.1",
-  "kustomization/components/unifi-network-application": "1.0.0"
+  "kustomization/components/unifi-network-application": "1.0.0",
+  "renovate-config": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,6 +47,10 @@
     "kustomization/components/unifi-network-application": {
       "package-name": "kustomize-unifi-network-application",
       "release-type": "simple"
+    },
+    "renovate": {
+      "package-name": "renovate-config",
+      "release-type": "simple"
     }
   },
   "separate-pull-requests": true,

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -1,0 +1,9 @@
+# Shareable Renovate Config
+
+This is a set of [Renovate](https://docs.renovatebot.com/) configurations that can be extended. To use, take advantage
+of the [shareable config presets](https://docs.renovatebot.com/config-presets/) feature! Simply add
+`github>marinatedconcrete/config//renovate` to your `extends` list. You can even tag it with an appropriate version if
+you would like by added `#renovate-config@v{version}` to the end, such that version `1.0.0` would look like
+`github>marinatedconcrete/config//renovate#renovate-config@v1.0.0`.
+
+[Here is a full list of GitHub releases](https://github.com/marinatedconcrete/config/releases?q=%22renovate-config%22).

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "marinatedconcrete/config",
+      "fileMatch": [
+        "^kustomization/.+/.+/kustomization\\.yml$",
+        "^kustomization/.+/.+/.+/kustomization\\.yml$"
+      ],
+      "matchStrings": [
+        "- https://github\\.com/marinatedconcrete/config/releases/download/(?<currentValue>.*?)/",
+        "- https://github\\.com/marinatedconcrete/config/?\\?ref=(?<currentValue>.+?)$"
+      ]
+    }
+  ],
+  "extends": ["config:best-practices"],
+  "packageRules": [
+    {
+      "description": "marinatedconcrete/config versioning",
+      "matchPackageNames": ["marinatedconcrete/config"],
+      "versioning": "regex:^(?<compatibility>.*)@v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
+    }
+  ],
+  "timezone": "America/Los_Angeles"
+}


### PR DESCRIPTION
We can use this in each of our repositories.  To start, it adds support for our package versioning and where to look for it in our repositories. This assumes a layout that is suggested by kustomize:
- `kustomization`
  - `bases`
  - `components`
  - `overlays`

Closes #249