### PR TITLE
fix: track versioned components in devcontainer spec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,9 +28,9 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      // renovate: datasource=deb depName=moby-cli
+      // renovate: deb=moby-cli repository=https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod
       "version": "27.4.1",
-      // renovate: datasource=deb depName=moby-buildx
+      // renovate: deb=moby-buildx repository=https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod
       "mobyBuildxVersion": "0.19.3",
       // We don't need this
       "dockerDashComposeVersion": "none"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommitScope(package)"],
+  "extends": [
+    "config:recommended",
+    ":semanticCommitScope(package)",
+    "github>marinatedconcrete/config//renovate/marinatedconcrete#renovate-config-2.0.0",
+    "github>marinatedconcrete/config//renovate/devcontainer#renovate-config-2.0.0"
+  ],
   "timezone": "America/Los_Angeles",
   "configMigration": true,
   "commitBody": "{{{releaseNotes}}}",
@@ -74,12 +79,10 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^.*\\.yml$", ".devcontainer/devcontainer.json"],
+      "fileMatch": ["^.*\\.yml$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+version:\\s+\"(?<currentValue>.*?)\"",
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+\"(v|\\w+V)ersion\":\\s+\"(?<currentValue>.*?)\""
-      ],
-      "registryUrlTemplate": "https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+version:\\s+\"(?<currentValue>.*?)\""
+      ]
     },
     {
       "customType": "regex",


### PR DESCRIPTION
This fixes #269.

The original commit, 3143f97673cb8c899405c79c5fc6d2be279bd158, did not properly setup the renovate file to parse these.  Since we now have a shared config that can do that for us (pending release of 2.0.0 in #270), this change undoes the work in the original commit and instead depends on our shared config to pick it up.

Validated with these two tests of our updated config:
* https://regex101.com/r/SE5Vfw/1
* https://regex101.com/r/ocT8Ie/1