### PR TITLE
Remove gh-cli from the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,10 +42,6 @@
     "ghcr.io/devcontainers/features/git:1": {
       "version": "os-provided"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      // renovate: datasource=github-releases depName=cli/cli
-      "version": "2.68.1"
-    },
     "ghcr.io/dhoeric/features/hadolint:1": {
       // renovate: datasource=github-releases depName=hadolint/hadolint
       "version": "2.12.0"


### PR DESCRIPTION
This is something that should be handled in the per-user VSCode settings rather than include it (and update it) for everyone