### PR TITLE
fix: remove renovate deb matching

### DIFF
--- a/renovate/devcontainer.json
+++ b/renovate/devcontainer.json
@@ -7,14 +7,6 @@
       "matchStrings": [
         "//\\s*renovate: datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\s+\".*[Vv]ersion\":\\s*\"(?<currentValue>.+?)\""
       ]
-    },
-    {
-      "customType": "regex",
-      "datasourceTemplate": "deb",
-      "fileMatch": ["^.devcontainer/devcontainer.json$"],
-      "matchStrings": [
-        "//\\s*renovate: deb=(?<depName>.+?)\\s+repository=(?<repositoryUrl>.+?)\\s+\".*[Vv]ersion\":\\s*\"(?<currentValue>.+?)\""
-      ]
     }
   ]
 }


### PR DESCRIPTION
This doesn't seem to work in practice (or at least we never figured out the right syntax).