### PR TITLE
fix: use docker-outside-of-docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,11 +28,11 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      // renovate: deb=moby-cli repository=https://packages.microsoft.com/debian?binaryArch=all&components=main&release=bullseye
-      "version": "27.5.0-debian12u1",
-      // renovate: deb=moby-buildx repository=https://packages.microsoft.com/debian?binaryArch=all&components=main&release=bullseye
-      "mobyBuildxVersion": "0.19.3-debian12u1",
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      // renovate: datasource=github-releases depName=moby/moby
+      "version": "28.0.4",
+      // renovate: datasource=github-releases depName=moby/buildkit
+      "mobyBuildxVersion": "0.21.0",
       // We don't need this
       "dockerDashComposeVersion": "none"
     },


### PR DESCRIPTION
This should work more efficiently than docker-in-docker.  Also taking a stab at trying to fix our version matching again.