### PR TITLE
fix: stop badly pinning docker-in-docker versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,10 +29,6 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      // renovate: deb=moby-cli repository=https://packages.microsoft.com/debian?binaryArch=all&components=main&release=bullseye
-      "version": "27.5.0-debian12u1",
-      // renovate: deb=moby-buildx repository=https://packages.microsoft.com/debian?binaryArch=all&components=main&release=bullseye
-      "mobyBuildxVersion": "0.19.3-debian12u1",
       // We don't need this
       "dockerDashComposeVersion": "none"
     },


### PR DESCRIPTION
We cannot get renovate to upgrade these properly, so `latest` is likely good enough.  It seems like something is broken with the pinned versions we have in here on my laptop as it is (I cannot run minikube anymore in the devcontainer).