### PR TITLE
fix: update RBAC for kube-vip

### DIFF
--- a/kustomization/components/kube-vip/rbac.yml
+++ b/kustomization/components/kube-vip/rbac.yml
@@ -14,25 +14,54 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - endpoints
-      - nodes
-      - services
       - services/status
     verbs:
-      - list
-      - get
-      - watch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
     verbs:
-      - list
-      - get
-      - watch
-      - update
       - create
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Their suggested settings have changed, and we were missing some of it: https://kube-vip.io/manifests/rbac.yaml

Sadly, this isn't versioned in their repository anywhere, so we can't pin it to a version.