### PR TITLE
fix: workaround docker-in-docker issue on newer fedora kernel

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -6,3 +6,8 @@ set -e
 yarn --immutable
 
 ansible-galaxy collection install --no-cache ansible
+
+# https://github.com/devcontainers/features/issues/1235
+if uname -r | grep -q '\.fc'; then
+  sudo update-alternatives --set iptables /usr/sbin/iptables-nft
+fi


### PR DESCRIPTION
As noted in https://github.com/devcontainers/features/issues/1235, the docker-in-docker feature simply always forces the use of `iptables-legacy`.  This doesn't work in newer fedora kernels, and so this just does a quick `uname` check to verify that we have it, and swaps to `iptables-nftables` if it matches.