### PR TITLE
!feat: generate kube-vip manifest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         libssh-dev \
+        yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,9 @@
         "nefrob.vscode-just-syntax",
         "redhat.vscode-yaml"
       ],
+      "files.readonlyInclude": {
+        "kustomization/components/kube-vip/daemonset.yml": true
+      },
       "settings": {
         "prettier.useEditorConfig": false,
         "search.exclude": {

--- a/kustomization/components/kube-vip/README.md
+++ b/kustomization/components/kube-vip/README.md
@@ -31,3 +31,73 @@ kind: Kustomization
 resources:
   - https://github.com/marinatedconcrete/config/releases/download/kustomize-kube-vip@v{version}/kube-vip.yml
 ```
+
+# Patches
+
+## Required
+
+### Set the VIP Address
+
+This is the controlplane VIP address for your cluster.
+
+#### `kustomization.yml`
+
+```yaml
+patches:
+  - path: patches/set_kube-vip_address.yml
+    target:
+      kind: DaemonSet
+      name: kube-vip-ds
+```
+
+#### `patches/set_kube-vip_address.yml`
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: this-is-ignored-but-is-required
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: address
+              value: 233.252.0.42
+          name: kube-vip
+```
+
+## Optional
+
+### Namespace
+
+If you do not deploy this to the `kube-vip` namespace, you will need to tell kube-vip what namespace it is deployed to.
+
+#### `kustomization.yml`
+
+```yaml
+patches:
+  - path: patches/set_kube-vip_namespace.yml
+    target:
+      kind: DaemonSet
+      name: kube-vip-ds
+```
+
+#### `patches/set_kube-vip_namespace.yml`
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: this-is-ignored-but-is-required
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: cp_namespace
+              value: totally-new-namespace
+          name: kube-vip
+```

--- a/kustomization/components/kube-vip/daemonset.yml
+++ b/kustomization/components/kube-vip/daemonset.yml
@@ -1,8 +1,14 @@
+# @codegen-command: just codegen-kube-vip-daemonset
+# @generated
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+    app.kubernetes.io/version: v0.8.10
   name: kube-vip-ds
+  namespace: kube-vip
 spec:
   selector:
     matchLabels:
@@ -11,11 +17,15 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-vip-ds
+        app.kubernetes.io/version: v0.8.10
     spec:
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
               - matchExpressions:
                   - key: node-role.kubernetes.io/control-plane
                     operator: Exists
@@ -27,34 +37,44 @@ spec:
               value: "true"
             - name: cp_namespace
               value: kube-vip
+            - name: dns_mode
+              value: first
             - name: port
               value: "6443"
             - name: svc_election
               value: "true"
             - name: svc_enable
               value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
             - name: vip_arp
               value: "true"
-            - name: vip_ddns
-              value: "false"
             - name: vip_cidr
               value: "32"
             - name: vip_leaderelection
               value: "true"
             - name: vip_leaseduration
               value: "5"
+            - name: vip_leasename
+              value: plndr-cp-lock
+            - name: vip_nodename
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: vip_renewdeadline
               value: "3"
             - name: vip_retryperiod
               value: "1"
           image: ghcr.io/kube-vip/kube-vip
+          imagePullPolicy: IfNotPresent
           name: kube-vip
           securityContext:
             capabilities:
               add:
                 - NET_ADMIN
                 - NET_RAW
-                - SYS_TIME
+              drop:
+                - ALL
       hostNetwork: true
       priorityClassName: critical-application-infra
       serviceAccountName: kube-vip

--- a/kustomization/tests/kube-vip/kustomization.yml
+++ b/kustomization/tests/kube-vip/kustomization.yml
@@ -12,11 +12,14 @@ patches:
       kind: DaemonSet
       metadata:
         name: kube-vip-ds
+        namespace: kube-vip
       spec:
         template:
           spec:
             containers:
               - env:
+                  - name: cp_namespace
+                    value: kube-vip-test
                   - name: vip_address
                     value: 192.168.42.42
                 name: kube-vip

--- a/renovate.json
+++ b/renovate.json
@@ -87,6 +87,13 @@
       "depNameTemplate": "ansible-core",
       "fileMatch": ["^ansible/meta/runtime\\.yml$"],
       "matchStrings": ["requires_ansible:\\s*\">=(?<currentValue>.*?)\""]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^justfile$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\n\\s+?[A-Z_]+_VERSION=(?<currentValue>.+?)$"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is a breaking change because it potentially breaks patching, as the namespace may have to be added to patch files as seen in the test updates in this change.

This uses kube-vip's manifest generation utility, which their docs really push you to use.  This is versioned with the kube-vip release in our repository, which is synced with renovate.

This change also documents the required and optional patches for kube-vip.

Tested renovate config settings with https://regex101.com/r/FwnumZ/1