### PR TITLE
fix: handle syntax change for volume claim templates

### DIFF
--- a/kustomization/components/factorio/statefulset.yml
+++ b/kustomization/components/factorio/statefulset.yml
@@ -55,7 +55,9 @@ spec:
       securityContext:
         fsGroup: 65536
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         labels:
           # Use this PVC to configure attached PVs.
           recurring-job.longhorn.io/source: enabled
@@ -71,7 +73,9 @@ spec:
           requests:
             storage: 5Gi
         storageClassName: longhorn-encrypted
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         labels:
           # Use this PVC to configure attached PVs.
           recurring-job.longhorn.io/source: enabled
@@ -87,7 +91,9 @@ spec:
           requests:
             storage: 10Gi
         storageClassName: longhorn-unencrypted
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         labels:
           # Use this PVC to configure attached PVs.
           recurring-job.longhorn.io/source: enabled
@@ -103,7 +109,9 @@ spec:
           requests:
             storage: 20Gi
         storageClassName: longhorn-unencrypted
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         labels:
           # Use this PVC to configure attached PVs.
           recurring-job.longhorn.io/source: enabled

--- a/kustomization/components/unifi-network-application/statefulset.yml
+++ b/kustomization/components/unifi-network-application/statefulset.yml
@@ -156,7 +156,9 @@ spec:
             name: una-mongodb-scripts-configmap
           name: mongodb-scripts
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: mongodb-data
       spec:
         accessModes:
@@ -165,7 +167,9 @@ spec:
           requests:
             storage: 1Gi
         storageClassName: longhorn-encrypted
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: unifi-config
       spec:
         accessModes:


### PR DESCRIPTION
I recently moved to using server side apply for all of my argocd applications, and now many things are showing up as out of sync.  It looks like we've always been using a shorthand for PVCs that becomes more apparent once you use server side apply.

This changes fixes that by setting the `apiVersion` and `kind` for each `volumeClaimTemplate` in our `StatefulSet`s.