### PR TITLE
fix: Add more information to better identify our image

### DIFF
--- a/.github/workflows/image-kairos-ubuntu.yml
+++ b/.github/workflows/image-kairos-ubuntu.yml
@@ -16,9 +16,6 @@ on: # yamllint disable-line rule:truthy
     paths:
       - .github/workflows/image-kairos-ubuntu.yml
       - images/kairos-ubuntu/**
-  release:
-    types:
-      - created
 
 jobs:
   build-container:
@@ -51,7 +48,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           build-args: |
-            VERSION=${{ steps.version_tag.outputs.tag }}
+            VERSION=${{ steps.version_tag.outputs.tag }}-${{ github.repository_owner }}-kairos-ubuntu
           context: images/kairos-ubuntu
           labels: ${{ steps.metadata.outputs.labels }}
           push: ${{ github.ref_type == 'tag' }}


### PR DESCRIPTION
Currently, the `KAIROS_IMAGE_LABEL`, `KAIROS_RELEASE`, and `KAIROS_VERSION` all are pretty generic in our custom image.  This change updates CI to pass in additional information to the `VERSION` such that `/etc/kairos-release` contains more useful information.

Veriefied by building with:
```
docker \
  build \
  images/kairos-ubuntu/ \
  --build-arg VERSION=0.1.4-marinatedconcrete-kairos-ubuntu
```

Then I ran:
```
docker \
  run \
  -it \
  sha256:1cc37f587d5177fb9f33dcf8da9cfa447b14014d0c5c4c67729f9fdddce26a1c \
  cat /etc/kairos-release
```

Which output this:
```
KAIROS_ARCH="amd64"
KAIROS_BUG_REPORT_URL="https://github.com/kairos-io/kairos/issues"
KAIROS_FAMILY="debian"
KAIROS_FIPS="false"
KAIROS_FLAVOR="ubuntu"
KAIROS_FLAVOR_RELEASE="24.04"
KAIROS_FRAMEWORK_VERSION="v2.20.0"
KAIROS_HOME_URL="https://github.com/kairos-io/kairos"
KAIROS_ID="kairos"
KAIROS_ID_LIKE="kairos-standard-ubuntu-24.04"
KAIROS_IMAGE_LABEL="24.04-standard-amd64-generic-v0.1.4-marinatedconcrete-kairos-ubuntu"
KAIROS_MODEL="generic"
KAIROS_NAME="kairos-standard-ubuntu-24.04"
KAIROS_REGISTRY_AND_ORG="quay.io/kairos"
KAIROS_RELEASE="v0.1.4-marinatedconcrete-kairos-ubuntu"
KAIROS_SOFTWARE_VERSION="1.31.4+k3s1"
KAIROS_SOFTWARE_VERSION_PREFIX="k3s"
KAIROS_TARGETARCH="amd64"
KAIROS_VARIANT="standard"
KAIROS_VERSION="v0.1.4-marinatedconcrete-kairos-ubuntu"
```

For context, this is what we have in our image now:
```
KAIROS_ARCH="amd64"
KAIROS_BUG_REPORT_URL="https://github.com/kairos-io/kairos/issues"
KAIROS_FAMILY="debian"
KAIROS_FIPS="false"
KAIROS_FLAVOR="ubuntu"
KAIROS_FLAVOR_RELEASE="24.04"
KAIROS_FRAMEWORK_VERSION="v2.20.0"
KAIROS_HOME_URL="https://github.com/kairos-io/kairos"
KAIROS_ID="kairos"
KAIROS_ID_LIKE="kairos-standard-ubuntu-24.04"
KAIROS_IMAGE_LABEL="24.04-standard-amd64-generic-v0.1.3"
KAIROS_MODEL="generic"
KAIROS_NAME="kairos-standard-ubuntu-24.04"
KAIROS_REGISTRY_AND_ORG="quay.io/kairos"
KAIROS_RELEASE="v0.1.3"
KAIROS_SOFTWARE_VERSION="1.31.4+k3s1"
KAIROS_SOFTWARE_VERSION_PREFIX="k3s"
KAIROS_TARGETARCH="amd64"
KAIROS_VARIANT="standard"
KAIROS_VERSION="v0.1.3"
```