### PR TITLE
fix: renovate does not handle `^` and `$` in `matchStrings`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -85,7 +85,7 @@
       "customType": "regex",
       "fileMatch": ["^.*Dockerfile$"],
       "matchStrings": [
-        "^#\\s*renovate:\\s*datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\nARG\\s+[A-Z_]+_VERSION=(?<currentValue>.+?)$"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\nARG\\s+[A-Z_]+_VERSION=(?<currentValue>.+?)\\n"
       ]
     },
     {
@@ -107,7 +107,7 @@
       "customType": "regex",
       "fileMatch": ["^justfile$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\n\\s+?[A-Z_]+_VERSION=(?<currentValue>.+?)$"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\n\\s+?[A-Z_]+_VERSION=(?<currentValue>.+?)\\n"
       ]
     }
   ]


### PR DESCRIPTION
From the docs:
> The `regex` manager matches are done per-file, not per-line! This
> means the `^` and `$` regex assertions only match the beginning
> and end of the entire file.

This fixes our two broken matchers.