### PR TITLE
fix: make it easier to override the namespace

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,6 +56,10 @@ codegen-kube-vip-daemonset:
     # Remove prometheus_server.
     yq -iy 'del(.spec.template.spec.containers[0].env[] | select(.name == "prometheus_server"))' ${SCRATCH}
 
+    # Set cp_namespace via a reference.
+    yq -iy 'del(.spec.template.spec.containers[0].env[] | select(.name == "cp_namespace") | .value)' ${SCRATCH}
+    yq -iy '(.spec.template.spec.containers[0].env[] | select(.name == "cp_namespace") | .valueFrom.fieldRef.fieldPath) = "metadata.namespace"' ${SCRATCH}
+
     # Add our priorityClassName to the manifest.
     yq -iy '.spec.template.spec.priorityClassName = "critical-application-infra"' ${SCRATCH}
 

--- a/kustomization/components/kube-vip/README.md
+++ b/kustomization/components/kube-vip/README.md
@@ -67,37 +67,3 @@ spec:
               value: 233.252.0.42
           name: kube-vip
 ```
-
-## Optional
-
-### Namespace
-
-If you do not deploy this to the `kube-vip` namespace, you will need to tell kube-vip what namespace it is deployed to.
-
-#### `kustomization.yml`
-
-```yaml
-patches:
-  - path: patches/set_kube-vip_namespace.yml
-    target:
-      kind: DaemonSet
-      name: kube-vip-ds
-```
-
-#### `patches/set_kube-vip_namespace.yml`
-
-```yaml
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: this-is-ignored-but-is-required
-spec:
-  template:
-    spec:
-      containers:
-        - env:
-            - name: cp_namespace
-              value: totally-new-namespace
-          name: kube-vip
-```

--- a/kustomization/components/kube-vip/daemonset.yml
+++ b/kustomization/components/kube-vip/daemonset.yml
@@ -36,7 +36,9 @@ spec:
             - name: cp_enable
               value: "true"
             - name: cp_namespace
-              value: kube-vip
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: dns_mode
               value: first
             - name: port

--- a/kustomization/tests/kube-vip/kustomization.yml
+++ b/kustomization/tests/kube-vip/kustomization.yml
@@ -18,8 +18,6 @@ patches:
           spec:
             containers:
               - env:
-                  - name: cp_namespace
-                    value: kube-vip-test
                   - name: vip_address
                     value: 192.168.42.42
                 name: kube-vip


### PR DESCRIPTION
This updates codegen to use a `fieldRef` instead of requiring a patch if one changes the deployed namespace.

This is also safer, because it's easy to forget to update this, and then find that kube-vip isn't working correctly.