### PR TITLE
fix: running `just lint` creates `ansible/.ansible`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 .ansible_vault_password
+ansible/.ansible
 
 # Yarn-specific
 # See https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored


### PR DESCRIPTION
This looks like a working directory for collections and roles, among other things.  We should ignore this.