### PR TITLE
Fix devcontainer for Fedora

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "config",
   "build": {
-    "cacheFrom": "ghcr.io/marinatedconcrete/config-devcontainer:latest",
+    "cacheFrom": "ghcr.io/marinatedconcrete/config-devcontainer",
     "context": "..",
     "dockerfile": "Dockerfile"
   },
@@ -81,5 +81,6 @@
     }
   },
   "postCreateCommand": ".devcontainer/post-create-command.sh",
+  "containerUser": "vscode",
   "remoteUser": "vscode"
 }


### PR DESCRIPTION
There's more to do on the Fedora system itself to get the permissions right for podman.
