### PR TITLE
Don't try to build kairos-ubuntu image on every release

### DIFF
--- a/.github/workflows/image-kairos-ubuntu.yml
+++ b/.github/workflows/image-kairos-ubuntu.yml
@@ -16,9 +16,6 @@ on: # yamllint disable-line rule:truthy
     paths:
       - .github/workflows/image-kairos-ubuntu.yml
       - images/kairos-ubuntu/**
-  release:
-    types:
-      - created
 
 jobs:
   build-container:


### PR DESCRIPTION
I think this line was in error and while I could refine it to only look at certain releases, I think @sdwilsh intended for this trigger to be removed.