### PR TITLE
Fix nodejs package name in automerge rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "packageRules": [
     {
       "description": "Automerge all js infra, and gh-cli changes",
-      "matchPackageNames": ["prettier", "@yarnpkg/cli", "cli/cli", "nodejs/node"],
+      "matchPackageNames": ["prettier", "@yarnpkg/cli", "cli/cli", "node"],
       "automerge": true,
       "automergeSchedule": ["every day"]
     },


### PR DESCRIPTION
Had to run the renovate CLI with `LOG_LEVEL=debug renovate --dry-run=full --platform=local 2>&1 | less` to get it to spit out what the package name is. I once again inferred incorrectly from the PR.

If correct, this should unblock the pending Node JS upgrade PR (#347) to automerge.