### PR TITLE
feat: Get the vscode-ssh-package to build

### DIFF
--- a/images/vscode-ssh-server/README.md
+++ b/images/vscode-ssh-server/README.md
@@ -1,7 +1,7 @@
 # Marinated Concrete's VSCode-compatible ssh server
 This runs a little ssh server that's compatible with VSCode's remote SSH feature. Unfortunately, [the LinuxServer one](https://docs.linuxserver.io/images/docker-openssh-server/) cannot be used because it is based on Alpine so it lacks glibc, a [known limitation](https://code.visualstudio.com/docs/remote/ssh#_remote-ssh-limitations).
 
-It's also less flexible/more opinionated. The intention is to run it as a sidecar to an existing application you have, such as esphome, HomeAssistant, or zwavejs.
+It's also less flexible/more opinionated. The intention is to run it as a sidecar to an existing application you have, such as esphome, HomeAssistant, or zwave-js.
 
 ## Configuration:
 In a new container alongside your application's container:


### PR DESCRIPTION
Touching the readme should be sufficient, along with a commit that has the semantic commit message
