### PR TITLE
Revert "chore(package): update googleapis/release-please-action action to v4.2.0"

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
       kustomize-unifi-network-application--release_created: ${{ steps.releases.outputs.kustomize-unifi-network-application--release_created }}
       kustomize-unifi-network-application--tag_name: ${{ steps.releases.outputs.kustomize-unifi-network-application--tag_name }}
     steps:
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+      - uses: googleapis/release-please-action@5792afc6b46e9bb55deda9eda973a18c226bc3fc # v4.1.5
         id: release-please
         with:
           token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts marinatedconcrete/config#296 as we discussed, to see if this addresses the issue with not getting new releases.