### PR TITLE
fix: Fix tag trigger for vscode-ssh-server

### DIFF
--- a/.github/workflows/image-vscode-ssh-server.yml
+++ b/.github/workflows/image-vscode-ssh-server.yml
@@ -9,7 +9,7 @@ on: # yamllint disable-line rule:truthy
       - .github/workflows/image-vscode-ssh-server.yml
       - images/vscode-ssh-server/**
     tags:
-      - vscode-ssh-server@v*
+      - vscode-ssh-server-*
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The tags are generated using the `-` instead of `@` and there's no `v` prefix. Maybe we try this before #371? I did a quick check for new issues for it and I don't see anything.