### PR TITLE
feat!: split kube-vip service and control plane VIP DaemonSets

### DIFF
--- a/kustomization/components/kube-vip/README.md
+++ b/kustomization/components/kube-vip/README.md
@@ -2,9 +2,10 @@
 
 [![Current Version](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=version&query=%24.kustomization%2Fcomponents%2Fkube-vip&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmarinatedconcrete%2Fconfig%2Frefs%2Fheads%2Fmain%2F.release-please-manifest.json)](https://github.com/marinatedconcrete/config/releases?q=%22kustomize-kube-vip%22)
 [![Pod Security Standard: Privileged](https://img.shields.io/badge/pod_security_standard-privileged-red?style=for-the-badge&logo=kubernetes&logoColor=%23326CE5)](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
-[![Priority Class](https://img.shields.io/badge/dynamic/yaml?style=for-the-badge&label=priorityclass&url=https%3A%2F%2Fgithub.com%2Fmarinatedconcrete%2Fconfig%2Fraw%2Frefs%2Fheads%2Fmain%2Fkustomization%2Fcomponents%2Fkube-vip%2Fdaemonset.yml&query=%24.spec.template.spec.priorityClassName)](https://github.com/marinatedconcrete/config/tree/main/kustomization/components/priorityclass)
 
-This will deploy [kub-vip](https://kube-vip.io/).
+This will deploy [kub-vip](https://kube-vip.io/) as two `DaemonSet`s:
+1) for the control plane
+2) for all services' ingress IP address
 
 # Example Usage
 
@@ -63,7 +64,7 @@ spec:
     spec:
       containers:
         - env:
-            - name: address
+            - name: vip_address
               value: 233.252.0.42
           name: kube-vip
 ```

--- a/kustomization/components/kube-vip/daemonset/services.yml
+++ b/kustomization/components/kube-vip/daemonset/services.yml
@@ -1,0 +1,52 @@
+# @codegen-command: just codegen-kube-vip
+# @generated
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+    app.kubernetes.io/version: v0.9.1
+  name: kube-vip-svc-ds
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-vip-svc-ds
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-vip-svc-ds
+        app.kubernetes.io/version: v0.9.1
+    spec:
+      containers:
+        - args:
+            - manager
+          env:
+            - name: cp_namespace
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: svc_election
+              value: "true"
+            - name: svc_enable
+              value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
+            - name: vip_arp
+              value: "true"
+            - name: vip_nodename
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: ghcr.io/kube-vip/kube-vip
+          imagePullPolicy: IfNotPresent
+          name: kube-vip
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+              drop:
+                - ALL
+      hostNetwork: true
+      serviceAccountName: kube-vip

--- a/kustomization/components/kube-vip/daemonset/vip.yml
+++ b/kustomization/components/kube-vip/daemonset/vip.yml
@@ -42,12 +42,6 @@ spec:
               value: first
             - name: port
               value: "6443"
-            - name: svc_election
-              value: "true"
-            - name: svc_enable
-              value: "true"
-            - name: svc_leasename
-              value: plndr-svcs-lock
             - name: vip_arp
               value: "true"
             - name: vip_leaderelection

--- a/kustomization/components/kube-vip/kustomization.yml
+++ b/kustomization/components/kube-vip/kustomization.yml
@@ -7,4 +7,5 @@ images:
     newTag: v0.9.1@sha256:37036d0f81745c4a5948abd069006264b699b3a98d26aadb24e63f86b7a3fdef
 resources:
   - rbac.yml
-  - daemonset.yml
+  - daemonset/services.yml
+  - daemonset/vip.yml


### PR DESCRIPTION
By default, kube-vip will route all traffic for services through the control plane.  This allows it to pick non-control planes in which to listen for service traffic (which it elects one node per service that needs an IP).