### PR TITLE
Migrate renovate configs to the new syntax

### DIFF
--- a/renovate/devcontainer.json
+++ b/renovate/devcontainer.json
@@ -3,7 +3,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^.devcontainer/devcontainer.json$"],
+      "managerFilePatterns": ["/^.devcontainer/devcontainer.json$/"],
       "matchStrings": [
         "//\\s*renovate: datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\s+\".*[Vv]ersion\":\\s*\"(?<currentValue>.+?)\""
       ]

--- a/renovate/marinatedconcrete.json
+++ b/renovate/marinatedconcrete.json
@@ -5,7 +5,7 @@
       "customType": "regex",
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "marinatedconcrete/config",
-      "fileMatch": ["^(.+/)+kustomization\\.yml$"],
+      "managerFilePatterns": ["/^(.+/)+kustomization\\.yml$/"],
       "matchStrings": [
         "- https://github\\.com/marinatedconcrete/config/releases/download/(?<currentValue>.*?)/",
         "- https://github\\.com/marinatedconcrete/config/?\\?ref=(?<currentValue>.+?)$"
@@ -15,7 +15,7 @@
       "customType": "regex",
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "marinatedconcrete/config",
-      "fileMatch": ["^renovate.json5?$"],
+      "managerFilePatterns": ["/^renovate.json5?$/"],
       "matchStrings": [
         "\"github>marinatedconcrete/config//renovate/.*#(?<currentValue>.+?)\""
       ]


### PR DESCRIPTION
Same as #382 but for our reusable renovate modules
