### PR TITLE
docs: Fix typos in docs

### DIFF
--- a/images/kairos-ubuntu/CHANGELOG.md
+++ b/images/kairos-ubuntu/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Bug Fixes
 
-* Specify the registory of our Kairos image ([#370](https://github.com/marinatedconcrete/config/issues/370)) ([dfdf173](https://github.com/marinatedconcrete/config/commit/dfdf1731f61a2d8f39705aac88d163be50b9704a))
+* Specify the registry of our Kairos image ([#370](https://github.com/marinatedconcrete/config/issues/370)) ([dfdf173](https://github.com/marinatedconcrete/config/commit/dfdf1731f61a2d8f39705aac88d163be50b9704a))
 
 
 ### Other Changes

--- a/kustomization/components/kube-vip/README.md
+++ b/kustomization/components/kube-vip/README.md
@@ -3,9 +3,10 @@
 [![Current Version](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=version&query=%24.kustomization%2Fcomponents%2Fkube-vip&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmarinatedconcrete%2Fconfig%2Frefs%2Fheads%2Fmain%2F.release-please-manifest.json)](https://github.com/marinatedconcrete/config/releases?q=%22kustomize-kube-vip%22)
 [![Pod Security Standard: Privileged](https://img.shields.io/badge/pod_security_standard-privileged-red?style=for-the-badge&logo=kubernetes&logoColor=%23326CE5)](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
 
-This will deploy [kub-vip](https://kube-vip.io/) as two `DaemonSet`s:
-1) for the control plane
-2) for all services' ingress IP address
+This will deploy [kube-vip](https://kube-vip.io/) as two `DaemonSet`s:
+
+1. for the control plane
+2. for all services' ingress IP address
 
 # Example Usage
 


### PR DESCRIPTION
## Summary
- fix a typo in the kube-vip README
- fix a typo in the kairos-ubuntu changelog

## Testing
- `npm run check-format`


------
https://chatgpt.com/codex/tasks/task_e_683a7e1e508c832b9b9d4e5935e54e10