### PR TITLE
chore: Install shellcheck via Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         libssh-dev \
+        shellcheck \
         yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,10 +69,6 @@
       // renovate: datasource=github-releases depName=casey/just
       "version": "1.40.0"
     },
-    "ghcr.io/marcozac/devcontainer-features/shellcheck:1": {
-      // renovate: datasource=github-releases depName=koalaman/shellcheck
-      "version": "v0.10.0"
-    },
     "ghcr.io/rio/features/kustomize:1": {
       // renovate: datasource=docker depName=registry.k8s.io/kustomize/kustomize
       "version": "v5.6.0"


### PR DESCRIPTION
## Summary
- drop devcontainer shellcheck feature (failing CI due to broken dependency)
- install shellcheck directly in the devcontainer Dockerfile