### PR TITLE
docs: instruct PR titles to follow conv commit style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,4 +16,5 @@
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) style. Commits from `sdwilsh` use types such as `feat`, `fix`, `docs`, `chore`, and `tests`, optionally with `!` for breaking changes (e.g., `feat!: rename ...`).
 - Keep the summary short and use the body to provide context if needed. Issue or PR references can be placed in parentheses after the summary, as seen in commits like `Add Mosquitto Kustomize Component (#74)`.
 - Signed commits are recommended as noted in commit `Support GPG Signing of Commits (#76)`.
+- Pull request titles should also follow the [Conventional Commits](https://www.conventionalcommits.org/) style so that PRs and commits use consistent semantic naming.
 


### PR DESCRIPTION
## Summary
- update AGENTS instructions about PR title naming

## Testing
- `yarn --immutable`
- `just format`
- `just check-format`
- `just lint` *(fails: `kustomize` not found)*
- `just test` *(fails: `minikube` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a6d8f918832ba7fe79ae4fe50d3f