### PR TITLE
chore: use github releases for kustomize

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,7 @@
       "version": "1.41.0"
     },
     "ghcr.io/rio/features/kustomize:1": {
-      // renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+      // renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/v(?<version>.*)$
       "version": "v5.6.0"
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,7 @@
       "version": "1.41.0"
     },
     "ghcr.io/rio/features/kustomize:1": {
-      // renovate: datasource=docker depName=registry.k8s.io/kustomize/kustomize
+      // renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
       "version": "v5.6.0"
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,7 @@
       "version": "1.41.0"
     },
     "ghcr.io/rio/features/kustomize:1": {
-      // renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/v(?<version>.*)$
+      // renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/v(?<version>.*)$
       "version": "v5.6.0"
     }
   },

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ ansible/.ansible
 
 # Kairos Factory dumps stuff under /build locally
 /build
-kustomize

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ansible/.ansible
 
 # Kairos Factory dumps stuff under /build locally
 /build
+kustomize

--- a/renovate/devcontainer.json
+++ b/renovate/devcontainer.json
@@ -5,7 +5,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/^.devcontainer/devcontainer.json$/"],
       "matchStrings": [
-        "//\\s*renovate: datasource=(?<datasource>.+?)\\s+depName=(?<depName>\\S+?)(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s+\\\".*[Vv]ersion\\\":\\s*\\\"(?<currentValue>.+?)\\\""
+        "//\\s*renovate: datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s+\\\".*[Vv]ersion\\\":\\s*\\\"(?<currentValue>.+?)\\\""
       ],
       "extractVersionTemplate": "{{extractVersion}}"
     }

--- a/renovate/devcontainer.json
+++ b/renovate/devcontainer.json
@@ -5,7 +5,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/^.devcontainer/devcontainer.json$/"],
       "matchStrings": [
-        "//\\s*renovate: datasource=(?<datasource>.+?)\\s+depName=(?<depName>.+?)\\s+\".*[Vv]ersion\":\\s*\"(?<currentValue>.+?)\""
+        "//\s*renovate: datasource=(?<datasource>.+?)\s+depName=(?<depName>\S+?)(?:\s+extractVersion=(?<extractVersion>\S+))?\s+\".*[Vv]ersion\":\s*\"(?<currentValue>.+?)\""
       ]
     }
   ]

--- a/renovate/devcontainer.json
+++ b/renovate/devcontainer.json
@@ -5,8 +5,9 @@
       "customType": "regex",
       "managerFilePatterns": ["/^.devcontainer/devcontainer.json$/"],
       "matchStrings": [
-        "//\s*renovate: datasource=(?<datasource>.+?)\s+depName=(?<depName>\S+?)(?:\s+extractVersion=(?<extractVersion>\S+))?\s+\".*[Vv]ersion\":\s*\"(?<currentValue>.+?)\""
-      ]
+        "//\\s*renovate: datasource=(?<datasource>.+?)\\s+depName=(?<depName>\\S+?)(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s+\\\".*[Vv]ersion\\\":\\s*\\\"(?<currentValue>.+?)\\\""
+      ],
+      "extractVersionTemplate": "{{extractVersion}}"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update Renovate kustomize comment to use GitHub releases

## Testing
- `just check-format`
- `just lint` *(fails: `kustomize` not found)*
- `just test` *(fails: running `minikube` fails)*

------
https://chatgpt.com/codex/tasks/task_e_6866d6f2b400832bbd78002f121fdfd1