### PR TITLE
fix: Update filename format

### DIFF
--- a/kustomization/components/paperless/statefulset.yml
+++ b/kustomization/components/paperless/statefulset.yml
@@ -59,7 +59,7 @@ spec:
             - name: PAPERLESS_DATE_ORDER
               value: MDY
             - name: PAPERLESS_FILENAME_FORMAT
-              value: "{correspondent}/{created_year}/{created_year}-{created_month}-{created_day} {title}"
+              value: "{{ correspondent }}/{{ created_year }}/{{ created_year }}-{{ created_month }}-{{ created_day }} {{ title }}"
             - name: PAPERLESS_TRASH_DIR
               value: "/usr/src/paperless/media/trash"
             - name: PAPERLESS_IGNORE_DATES


### PR DESCRIPTION
There is a warning about this:
```
?: Filename format {correspondent}/{created_year}/{created_year}-{created_month}-{created_day} {title} is using the old style, please update to use double curly brackets
        HINT: {{ correspondent }}/{{ created_year }}/{{ created_year }}-{{ created_month }}-{{ created_day }} {{ title }}
```

It looks like they've just migrated to Jinja