### PR TITLE
Switch Kustomize to use github releases

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,8 +70,8 @@
       "version": "1.41.0"
     },
     "ghcr.io/rio/features/kustomize:1": {
-      // renovate: datasource=docker depName=registry.k8s.io/kustomize/kustomize
-      "version": "v5.7.0"
+      // renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+      "version": "v5.6.0"
     }
   },
   "postCreateCommand": ".devcontainer/post-create-command.sh",

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
   "rollbackPrs": true,
   "packageRules": [
     {
+      "description": "Extract Kustomize's unusual release versions",
+      "matchPackageNames": ["kubernetes-sigs/kustomize"],
+      "extractVersion": "^kustomize/v(?<version>.*)$"
+    },
+    {
       "description": "Automerge all js infra, and gh-cli changes",
       "matchPackageNames": ["prettier", "@yarnpkg/cli", "cli/cli", "node"],
       "automerge": true,


### PR DESCRIPTION
I do not know if we had the `extractVersion` feature available before but it seems to simplify the setup here.
