### PR TITLE
chore(renovate): auto-merge monthly ubuntu digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,16 @@
       "schedule": ["on the first day of the month"]
     },
     {
+      "description": "Auto-merge ubuntu digest updates monthly",
+      "automerge": true,
+      "automergeType": "branch",
+      "groupName": "ubuntu",
+      "matchFileNames": ["images/kairos-ubuntu/Dockerfile"],
+      "matchPackageNames": ["ubuntu"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": ["on the first day of the month"]
+    },
+    {
       "description": "Auto-merge renovate updates monthly",
       "automerge": true,
       "automergeType": "branch",


### PR DESCRIPTION
## Summary
- auto-merge ubuntu digest updates monthly

## Testing
- `just format`
- `just check-format`
- `just lint` *(fails: kustomize: command not found)*
- `just test` *(fails: Recipe `kustomization-tests` failed with exit code 2)*

------
https://chatgpt.com/codex/tasks/task_e_689427ebd45c832b9c41e43b0bee95e3