### PR TITLE
feat: Ensure each thing we release is not grouped by renovate

### DIFF
--- a/renovate/marinatedconcrete.json
+++ b/renovate/marinatedconcrete.json
@@ -26,6 +26,59 @@
       "description": "marinatedconcrete/config versioning",
       "matchPackageNames": ["marinatedconcrete/config"],
       "versioning": "regex:^(?<compatibility>.+)[@\\-]v?(?<major>\\d+?)\\.(?<minor>\\d+?)\\.(?<patch>\\d+?)$"
+    },
+    {
+      "groupName": "marinatedconcrete Ansible Collection",
+      "matchCurrentValue": "ansible-collection@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete Kairos Ubuntu Image",
+      "groupSlug": "marinatedconcrete-kairos-ubuntu",
+      "matchCurrentValue": "kairos-ubuntu-**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete vscode SSH Server Image",
+      "groupSlug": "marinatedconcrete-vscode-ssh-server",
+      "matchCurrentValue": "vscode-ssh-server-**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete Factorio Kustomize Component",
+      "groupSlug": "marinatedconcrete-kustomize-factorio",
+      "matchCurrentValue": "kustomize-factorio@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete kube-vip Kustomize Component",
+      "groupSlug": "marinatedconcrete-kustomize-kube-vip",
+      "matchCurrentValue": "kustomize-kube-vip@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete Mosquitto Kustomize Component",
+      "groupSlug": "marinatedconcrete-kustomize-mosquitto",
+      "matchCurrentValue": "kustomize-mosquitto@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete Paperless Kustomize Component",
+      "groupSlug": "marinatedconcrete-kustomize-paperless",
+      "matchCurrentValue": "kustomize-paperless@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete Priority Classes Kustomize Component",
+      "groupSlug": "marinatedconcrete-kustomize-priorityclass",
+      "matchCurrentValue": "kustomize-priorityclass@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
+    },
+    {
+      "groupName": "marinatedconcrete Unifi Network Application Kustomize Component",
+      "groupSlug": "marinatedconcrete-kustomize-unifi-network-application",
+      "matchCurrentValue": "kustomize-unifi-network-application@**",
+      "matchPackageNames": ["marinatedconcrete/config"]
     }
   ]
 }


### PR DESCRIPTION
Renovate groups all the updates from this repository into a single Pull Request.  Ultimately, that's because they all share the same branch name.  We can override that by either changing the branch name (which can break other packages, so it is a bad idea), or by specifying a group for each package.

This solution is verbose, but it works great.  I was able to pull out a Unifi update in https://github.com/sdwilsh/ansible-playbooks/pull/1191, as an example.