### PR TITLE
Include the release notes in the body commit

### DIFF
--- a/renovate/recommended.json
+++ b/renovate/recommended.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "commitBodyTable": true,
+  "fetchChangeLogs": "branch",
+  "commitBody": "{{#if logJSON.hasReleaseNotes}}{{#each logJSON.versions as |release|}}{{# if release.releaseNotes}}##### [\\`{{{release.version}}}\\`]({{{release.releaseNotes.url}}})\n\n{{{release.releaseNotes.body}}}{{else}}##### [\\`{{{release.version}}}\\`]\n\nRelease notes not available{{/if}}{{#unless @last}}\n---\n{{/unless}}{{/each}}{{else}}{{releaseNotes}}{{/if}}",
   "extends": ["config:best-practices"],
   "rollbackPrs": true,
   "timezone": "America/Los_Angeles"


### PR DESCRIPTION
The actual version update is easy to read from the commit contents, so the table was not very useful. This does bloat the commit message quite a bit but it gives a good historical record. And maybe some day something will format this markdown nicely.
