### PR TITLE
feat: include python3-pexpect in our kairos image

### DIFF
--- a/images/kairos-ubuntu/Dockerfile
+++ b/images/kairos-ubuntu/Dockerfile
@@ -2,6 +2,10 @@
 
 FROM quay.io/kairos/kairos-init:v0.5.20@sha256:d90e8dd3d43f8c90b4cc9f76b1eb7282823737867dfdf5dda88a66c7683bccfc AS kairos-init
 
+# Allow build scripts to be referenced without being copied into the final image.
+FROM scratch AS ctx
+COPY build_files /
+
 FROM ubuntu:24.04@sha256:fdb6c9ceb1293dcb0b7eda5df195b15303b01857d7b10f98489e7691d20aa2a1 AS base-kairos
 LABEL org.opencontainers.image.title="A custom Ubuntu-based Kairos image."
 LABEL org.opencontainers.image.title="kairos-ubuntu"
@@ -26,7 +30,12 @@ RUN /kairos-init \
     --version "${VERSION}"
 
 # Our customizations!
-# This space intentionally left blank.
+# hadolint ignore=DL3059
+RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache \
+    --mount=type=cache,dst=/var/log \
+    --mount=type=tmpfs,dst=/tmp \
+    /ctx/customization.sh
 
 # Initialize the image.
 # hadolint ignore=DL3059

--- a/images/kairos-ubuntu/build_files/customization.sh
+++ b/images/kairos-ubuntu/build_files/customization.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ouex pipefail
+
+# Additional Packages
+PACKAGES=(
+    # Used by `ansible.builtin.expect`
+    "python3-pexpect"
+)
+
+apt-get update
+apt-get upgrade -y
+apt-get install -y --no-install-recommends "${PACKAGES[@]}"
+
+# Cleanup
+apt-get clean
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is needed for the [`ansible.builtin.expect`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/expect_module.html) module to work, which I am working on a play for to have our encrypted longhorn volumes be trim-able.