### PR TITLE
fix: exclude ansible/requirements.txt

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,6 +37,9 @@
           "type": "yaml"
         }
       ],
+      "exclude-paths": [
+        "ansible/requirements.txt"
+      ],
       "package-name": "ansible-collection",
       "release-type": "simple"
     },


### PR DESCRIPTION
This is only used for the devcontainer, and is not actually released. It should greatly cut down on spam for releases of this code.