### PR TITLE
feat: include a new role to allow encrypted trim

### DIFF
--- a/ansible/roles/longhorn_allow_encrypted_trim/README.md
+++ b/ansible/roles/longhorn_allow_encrypted_trim/README.md
@@ -1,0 +1,35 @@
+Role Name
+=========
+
+This role walks every Longhorn `Volume`, and enables the `discards` flag on it
+so that [the trim command can work](https://longhorn.io/docs/1.9.1/nodes-and-volumes/volumes/trim-filesystem/#encrypted-volumes).
+
+Requirements
+------------
+
+The target systems must have [`pexpect`](https://pypi.org/project/pexpect/) installed.
+
+Role Variables
+--------------
+
+
+Dependencies
+------------
+
+This requires the [kubernetes.core collection](https://galaxy.ansible.com/ui/repo/published/kubernetes/core/).
+
+Example Playbook
+----------------
+
+```
+---
+- hosts: localhost
+  gather_facts: false
+  roles:
+      - role: marinatedconcrete.config.longhorn_allow_encrypted_trim
+```
+
+License
+-------
+
+BSD-3-Clause

--- a/ansible/roles/longhorn_allow_encrypted_trim/meta/main.yml
+++ b/ansible/roles/longhorn_allow_encrypted_trim/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  author: Shawn Wilsher <me@shawnwilsher.com>
+  description: This role walks every Longhorn `Volume`, and enables the `discards` flag on it.
+
+  license: BSD-3-Clause
+
+  min_ansible_version: "2.18"

--- a/ansible/roles/longhorn_allow_encrypted_trim/tasks/main.yml
+++ b/ansible/roles/longhorn_allow_encrypted_trim/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# Tasks file for longhorn_allow_encrypted_trim.
+- name: Determine all StorageClasses
+  ansible.builtin.set_fact:
+    longhorn_allow_encrypted_trim_storage_classes_yaml: |-
+      ---
+      {%
+        for storage_class in query(
+          'kubernetes.core.k8s',
+          api_version='storage.k8s.io/v1',
+          kind='StorageClass',
+        )
+        | rejectattr('parameters.encrypted', 'undefined')
+        | selectattr('parameters.encrypted')
+      %}{{
+      storage_class.metadata.name + ':
+        namespace: ' + storage_class.parameters['csi.storage.k8s.io/node-publish-secret-namespace'] + '
+        secret: ' + storage_class.parameters['csi.storage.k8s.io/node-publish-secret-name'] + '
+      '
+      }}{%- endfor %}
+- name: Update each volume
+  ansible.builtin.include_tasks: process_volume.yml
+  loop: >-
+    {{
+      query(
+        'kubernetes.core.k8s',
+        api_version='longhorn.io/v1beta2',
+        kind='Volume',
+        namespace='longhorn-system',
+      )
+      | selectattr('status.state', '==', 'attached')
+      | selectattr('spec.encrypted', '==', true)
+    }}
+  loop_control:
+    label: >-
+      {{ volume.metadata.name }}
+      ({{ volume.status.kubernetesStatus.namespace }}/{{ volume.status.kubernetesStatus.pvcName }})
+    loop_var: volume

--- a/ansible/roles/longhorn_allow_encrypted_trim/tasks/process_volume.yml
+++ b/ansible/roles/longhorn_allow_encrypted_trim/tasks/process_volume.yml
@@ -1,0 +1,41 @@
+---
+# Tasks file for longhorn_allow_encrypted_trim to process each volume.
+- name: Get pv storageClass
+  ansible.builtin.set_fact:
+    longhorn_allow_encrypted_trim_storage_class: >-
+      {{
+        (
+          query(
+            'kubernetes.core.k8s',
+            kind='PersistentVolume',
+            resource_name=volume.status.kubernetesStatus.pvName,
+          )
+          | first
+        ).spec.storageClassName
+      }}
+- name: Persist allowing discards
+  ansible.builtin.expect:
+    command: "cryptsetup --allow-discards --persistent refresh {{ device }}"
+    responses:
+      "^Enter passphrase for ": "{{ encryption_key }}"
+  become: true
+  delegate_to: >-
+      {{
+        hostvars | list | select('match', '^' + volume.status.ownerID) | first
+      }}
+  no_log: true # This contains a secret!
+  vars:
+    device: "/dev/mapper/{{ volume.metadata.name }}"
+    encryption_key: >-
+      {{
+        (
+          query(
+            'kubernetes.core.k8s',
+            kind='Secret',
+            namespace=(longhorn_allow_encrypted_trim_storage_classes_yaml | from_yaml)[longhorn_allow_encrypted_trim_storage_class].namespace,
+            resource_name=(longhorn_allow_encrypted_trim_storage_classes_yaml | from_yaml)[longhorn_allow_encrypted_trim_storage_class].secret,
+          )
+          | first
+        ).data.CRYPTO_KEY_VALUE
+        | b64decode
+      }}

--- a/justfile
+++ b/justfile
@@ -164,7 +164,11 @@ format:
 ansible-lint:
     #!/usr/bin/env bash
     set -euo pipefail
+
+    # We need a valid .kube/context file for ansible-lint to be happy.
+    minikube start --interactive=false --profile=ansible-lint
     cd ansible && ansible-lint
+    minikube stop --profile=ansible-lint
 
 # Lint Dockerfiles with hado
 [group('lint')]


### PR DESCRIPTION
This accomplishes what is documented by Longhorn on how to enable the trim command to work:
https://longhorn.io/docs/1.9.1/nodes-and-volumes/volumes/trim-filesystem/#encrypted-volumes