### PR TITLE
feat: Enable iSCSI for kairos-fedora

### DIFF
--- a/images/kairos-fedora/build_files/configure.sh
+++ b/images/kairos-fedora/build_files/configure.sh
@@ -7,6 +7,11 @@ systemctl enable sshd.socket
 # Longhorn is not compatible with multipath.
 # See https://longhorn.io/kb/troubleshooting-volume-with-multipath/
 systemctl mask multipathd.service multipathd.socket multipathd-queueing.service
+# Longhorn requires these to be enabled
+# https://longhorn.io/docs/1.11.1/deploy/install/#installing-open-iscsi
+# We don't want to generate the initiatior name at build-time.
+# Instead, the iscsi-init service will do this for us
+systemctl enable iscsi-init.service iscsid.service iscsid.socket
 
 systemctl mask NetworkManager.service NetworkManager-wait-online.service
 systemctl enable systemd-networkd.service systemd-resolved.service

--- a/images/kairos-fedora/build_files/customization.sh
+++ b/images/kairos-fedora/build_files/customization.sh
@@ -4,6 +4,8 @@ set -ouex pipefail
 
 # Additional Packages
 PACKAGES=(
+    # Required by Longhorn for iSCSI volume support.
+    "iscsi-initiator-utils"
     "openssh-server"
     # Used by `ansible.builtin.expect`
     "python3-pexpect"


### PR DESCRIPTION
This must have been implicitly done for Ubuntu so we never noticed