### PR TITLE
fix(deps): fedora cannot be pinned

### DIFF
--- a/images/kairos-fedora/Containerfile
+++ b/images/kairos-fedora/Containerfile
@@ -6,7 +6,7 @@ FROM quay.io/kairos/kairos-init:v0.10.0@sha256:ed04343a44af73e1f916f6abdfdccf866
 FROM scratch AS ctx
 COPY build_files /
 
-FROM fedora:44@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2 AS base-kairos
+FROM fedora:44
 LABEL org.opencontainers.image.title="A custom Fedora-based Kairos image."
 LABEL org.opencontainers.image.title="kairos-fedora"
 ARG MODEL=generic

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,17 @@
   "rollbackPrs": true,
   "packageRules": [
     {
+      "enabled": false,
+      "groupName": "no-pin",
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest"
+      ],
+      "matchPackageNames": [
+        "fedora"
+      ]
+    },
+    {
       "description": "Extract Kustomize's unusual release versions",
       "matchPackageNames": ["kubernetes-sigs/kustomize"],
       "extractVersion": "^kustomize/v(?<version>.*)$"


### PR DESCRIPTION
They delete old pins (unsure how quickly, but I can't build current `main`).  We shouldn't pin this.  Sadly, this means no reproducible builds, but that's hard anyway since we install packages.