### PR TITLE
feat: add firmware to the fedora builds

### DIFF
--- a/images/kairos-fedora/build_files/customization.sh
+++ b/images/kairos-fedora/build_files/customization.sh
@@ -4,6 +4,16 @@ set -ouex pipefail
 
 # Additional Packages
 PACKAGES=(
+    # Required for AMD GPU initialization.
+    "amd-gpu-firmware"
+    # CPU microcode updates for AMD nodes.
+    "amd-ucode-firmware"
+    # Required for Intel Quick Sync/VAAPI on systems using i915.
+    "intel-gpu-firmware"
+    # CPU microcode updates for Intel nodes.
+    "microcode_ctl"
+    # Firmware for Realtek NICs, commonly used on our nodes
+    "realtek-firmware"
     # Required by Longhorn for iSCSI volume support.
     "iscsi-initiator-utils"
     "openssh-server"


### PR DESCRIPTION
We are missing this, and missing some functionality as a result. I avoided all wireless things, but if we do want that then it's probably easiest to just use the linux-firmware package instead of many of these individual ones.