### PR TITLE
fix(longhorn_allow_encrypted_trim): cryptsetup on fedora wants the path after /dev/mapper

### DIFF
--- a/ansible/roles/longhorn_allow_encrypted_trim/tasks/process_volume.yml
+++ b/ansible/roles/longhorn_allow_encrypted_trim/tasks/process_volume.yml
@@ -15,7 +15,7 @@
       }}
 - name: Persist allowing discards
   ansible.builtin.expect:
-    command: "cryptsetup --allow-discards --persistent refresh {{ device }}"
+    command: "cryptsetup --allow-discards --persistent refresh {{ device.removeprefix('/dev/mapper/') }}"
     responses:
       "^Enter passphrase for ": "{{ encryption_key }}"
   become: true


### PR DESCRIPTION
This also appears to work correctly on ubuntu (in both forms), but with fedora, it failed with the full path.