### PR TITLE
feat(devcontainer-base): Create a new base image for devcontainers

### DIFF
--- a/.github/workflows/image-devcontainer-base.yml
+++ b/.github/workflows/image-devcontainer-base.yml
@@ -1,0 +1,47 @@
+---
+name: Build Devcontainer Base Image
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/image-devcontainer-base.yml
+      - images/devcontainer-base/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/image-devcontainer-base.yml
+      - images/devcontainer-base/**
+  schedule:
+      - cron: '0 0 * * 0'  # Triggers every Sunday at midnight UTC
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate Metadata
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        id: metadata
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/devcontainer-base
+      - name: Build Image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: images/devcontainer-base
+          file: images/devcontainer-base/Containerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ github.repository_owner }}/devcontainer-base:latest

--- a/images/devcontainer-base/Containerfile
+++ b/images/devcontainer-base/Containerfile
@@ -1,0 +1,17 @@
+ARG USERNAME=vscode
+ARG USERID=1000
+ARG GROUPID=1000
+
+FROM scratch AS ctx
+COPY build_files /
+
+FROM quay.io/fedora/fedora-minimal:44
+
+RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache \
+    --mount=type=cache,dst=/var/log \
+    --mount=type=tmpfs,dst=/tmp \
+    /ctx/build.sh
+
+WORKDIR /home/${USERNAME}
+USER ${USERNAME}

--- a/images/devcontainer-base/README.md
+++ b/images/devcontainer-base/README.md
@@ -1,0 +1,7 @@
+# Marinated Concrete's Fedora-Based Devcontainer Image
+
+This is a Fedora-based devcontainer base image that can be used for more
+specific devcontainers.  The goal is to provide a small, minimal devcontainer
+image that works well with vscode.
+
+We automatically publish a new version weekly, or when relevant changes are made.

--- a/images/devcontainer-base/build_files/build.sh
+++ b/images/devcontainer-base/build_files/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ouex pipefail
+
+/ctx/packages.sh
+
+# Cleanup
+dnf clean all
+rm -rf /var/lib/dnf

--- a/images/devcontainer-base/build_files/packages.sh
+++ b/images/devcontainer-base/build_files/packages.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eoux pipefail
+
+# The set of packages that are needed for this build to work.
+CORE_PACKAGES=(
+    "curl"
+    "gzip"
+    "tar"
+)
+
+# The set of packages that we agree are too useful to not have in the base
+# image.
+COMMON_PACKAGES=(
+    # It's never DNS, but it's good to verify that...
+    "bind-utils"
+    "iproute"
+    "iputils"
+    # These are core utilities that seem silly to not include.
+    "coreutils"
+    "sudo"
+    "watch"
+    # Source Control
+    "diffutils"
+    "git"
+    # Editor of choice.
+    "vim"
+)
+
+dnf upgrade -y
+dnf install \
+    --setopt=install_weak_deps=False \
+    -y \
+    "${CORE_PACKAGES[@]}" \
+    "${COMMON_PACKAGES[@]}"
+
+# Now we can invoke some additional scripts for potentially more complicated installs.
+/ctx/packages/just.sh

--- a/images/devcontainer-base/build_files/packages/just.sh
+++ b/images/devcontainer-base/build_files/packages/just.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eoux pipefail
+
+# Just is so common and useful in our devcontainers, that we actually set it
+# up in the base image.
+
+# renovate: datasource=github-releases depName=casey/just
+JUST_VERSION=1.51.0
+  curl \
+    -s \
+    -L \
+    https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz | \
+        tar -xvzf - -C /tmp
+mv /tmp/just /usr/local/bin/just

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,8 @@
         "pinDigest"
       ],
       "matchPackageNames": [
-        "fedora"
+        "fedora",
+        "fedora-minimal"
       ]
     },
     {


### PR DESCRIPTION
A fedora-based image that we can use in various repos, including this one.

I'm not yet migrating ours...this needs to publish via the workflow first.

No tags here; we'll just depend on pinning.