### PR TITLE
fix(renovate): map kairos-fedora image changelog

### DIFF
--- a/renovate/marinatedconcrete.json
+++ b/renovate/marinatedconcrete.json
@@ -28,6 +28,13 @@
       "versioning": "regex:^(?<compatibility>.+)[@\\-]v?(?<major>\\d+?)\\.(?<minor>\\d+?)\\.(?<patch>\\d+?)$"
     },
     {
+      "description": "Map kairos-fedora image to its monorepo changelog",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/marinatedconcrete/kairos-fedora"],
+      "sourceDirectory": "images/kairos-fedora",
+      "sourceUrl": "https://github.com/marinatedconcrete/config"
+    },
+    {
       "groupName": "marinatedconcrete Ansible Collection",
       "matchCurrentValue": "ansible-collection@**",
       "matchPackageNames": ["marinatedconcrete/config"]


### PR DESCRIPTION
## Summary

Add a shared Renovate package rule for `ghcr.io/marinatedconcrete/kairos-fedora` so downstream Docker updates resolve release notes from the monorepo changelog at `images/kairos-fedora/CHANGELOG.md`.

## Context

Renovate was finding the image source repository, but without a source directory it only looked at the repository-level release/changelog path. This maps the image package to the Kairos Fedora image directory without changing image labels, annotations, or tags.

## Validation

- `just format`
- `just renovate-lint`