### PR TITLE
fix: allow renovate to resolve the ansible-galaxy package

### DIFF
--- a/renovate/marinatedconcrete.json
+++ b/renovate/marinatedconcrete.json
@@ -23,6 +23,14 @@
   ],
   "packageRules": [
     {
+      "description": "Normalize marinatedconcrete/config Ansible git collection",
+      "matchManagers": ["ansible-galaxy"],
+      "matchDatasources": ["github-tags"],
+      "matchDepNames": ["github.com/marinatedconcrete/config"],
+      "overrideDepName": "marinatedconcrete/config",
+      "overridePackageName": "marinatedconcrete/config"
+    },
+    {
       "description": "marinatedconcrete/config versioning",
       "matchPackageNames": ["marinatedconcrete/config"],
       "versioning": "regex:^(?<compatibility>.+)[@\\-]v?(?<major>\\d+?)\\.(?<minor>\\d+?)\\.(?<patch>\\d+?)$"


### PR DESCRIPTION
It was having trouble with the non-standard prefix and full git url
subpath. This should clear it up for all downstream repos using our
renovate config.
