### PR TITLE
fix(renovate): overriding the dep name breaks branch creation

### DIFF
--- a/renovate/marinatedconcrete.json
+++ b/renovate/marinatedconcrete.json
@@ -27,7 +27,6 @@
       "matchManagers": ["ansible-galaxy"],
       "matchDatasources": ["github-tags"],
       "matchDepNames": ["github.com/marinatedconcrete/config"],
-      "overrideDepName": "marinatedconcrete/config",
       "overridePackageName": "marinatedconcrete/config"
     },
     {


### PR DESCRIPTION
This didn't show up in my testing because the branch creation path
wasn't exercised. Now that it is (in prod), I can see that the
prior patch wasn't working. From the debug logs, it seems that renovate
is applying the update to requirements.yml, but it fails because it's
not re-applying the override when it verifies its edit by re-extracting
deps.

Log lines:
```
DEBUG: depName mismatch (branch="renovate/patch-marinatedconcrete-ansible-collection")
{
  "manager": "ansible-galaxy",
  "packageFile": "requirements.yml",
  "currentDepName": "marinatedconcrete/config",
  "newDepName": "github.com/marinatedconcrete/config"
}

WARN: Error updating branch: update failure (branch="renovate/patch-marinatedconcrete-ansible-collection")
```
