### PR TITLE
fix(renovate): do not pin fedora docker images from quay.io

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,16 +12,14 @@
   "rollbackPrs": true,
   "packageRules": [
     {
-      "enabled": false,
-      "groupName": "no-pin",
-      "matchUpdateTypes": [
-        "pin",
-        "pinDigest"
-      ],
+      "description": "Do not pin Fedora image digests because old digests disappear",
+      "matchDatasources": ["docker"],
       "matchPackageNames": [
         "fedora",
-        "fedora-minimal"
-      ]
+        "fedora-minimal",
+        "quay.io/fedora/**"
+      ],
+      "pinDigests": false
     },
     {
       "description": "Extract Kustomize's unusual release versions",


### PR DESCRIPTION
This resulted in #748 and #749 but we clearly don't intend to pin Fedora since they keep churning layers too quickly for the pin to be useful