### PR TITLE
feat: install Homebrew in github-runner-ci image

### DIFF
--- a/.github/workflows/image-github-runner-ci.yml
+++ b/.github/workflows/image-github-runner-ci.yml
@@ -81,6 +81,7 @@ jobs:
             test -w "$HOME/.local"
             test -w "$HOME/.local/bin"
             test -w "$HOME/.local/share"
+            brew --version
             git --version
             just --version
             jq --version
@@ -126,6 +127,11 @@ jobs:
           test -w "${HOME}/.local/share"
           test -w "${GITHUB_WORKSPACE}"
           test -w "${RUNNER_TEMP}"
+
+          brew --version
+          brew install hello
+          brew list --versions hello
+          hello --version
 
           touch "${GITHUB_WORKSPACE}/.github-runner-ci-write-test"
           rm "${GITHUB_WORKSPACE}/.github-runner-ci-write-test"

--- a/images/github-runner-ci/Containerfile
+++ b/images/github-runner-ci/Containerfile
@@ -13,16 +13,25 @@ ARG RUNNER_USER=runner
 ARG RUNNER_UID=1001
 ARG RUNNER_GID=1001
 
+RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/create-runner-user.sh
+
 RUN --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/build.sh
 
-RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
-    /ctx/create-runner-user.sh
-
 ENV HOME="/home/${RUNNER_USER}" \
+    HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar" \
+    HOMEBREW_NO_ANALYTICS="1" \
+    HOMEBREW_NO_AUTO_UPDATE="1" \
+    HOMEBREW_NO_ENV_HINTS="1" \
+    HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" \
+    HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew" \
+    LOGNAME="${RUNNER_USER}" \
+    PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}" \
+    USER="${RUNNER_USER}" \
     XDG_CACHE_HOME="/home/${RUNNER_USER}/.cache" \
     XDG_CONFIG_HOME="/home/${RUNNER_USER}/.config" \
     XDG_DATA_HOME="/home/${RUNNER_USER}/.local/share"

--- a/images/github-runner-ci/README.md
+++ b/images/github-runner-ci/README.md
@@ -4,10 +4,12 @@ This image is intended for GitHub Actions job containers running on ARC
 `kubernetes-novolume` runners.
 
 It inherits from `ghcr.io/marinatedconcrete/devcontainer-base`, installs a small
-set of common shell/system tools, and runs as `runner` with UID/GID `1001:1001`
-so job containers match the ownership of the ARC runner workspace. The default
-home directory is `/home/runner`, and it is writable by that user.
+set of common shell/system tools plus Homebrew, and runs as `runner` with
+UID/GID `1001:1001` so job containers match the ownership of the ARC runner
+workspace. The default home directory is `/home/runner`, and it is writable by
+that user.
 
 Language runtimes and domain-specific tools such as Node.js, Python, the GitHub
 CLI, Kubernetes tooling, and container-specific linters are intentionally left
-for downstream CI images or workflows to choose.
+for downstream CI images or workflows to choose. Workflows can use `brew` to
+install additional packages at job runtime.

--- a/images/github-runner-ci/build_files/create-runner-user.sh
+++ b/images/github-runner-ci/build_files/create-runner-user.sh
@@ -18,6 +18,7 @@ useradd \
 install -d \
     --owner "${RUNNER_USER}" \
     --group "${RUNNER_USER}" \
+    "/home/linuxbrew" \
     "/home/${RUNNER_USER}/.cache" \
     "/home/${RUNNER_USER}/.config" \
     "/home/${RUNNER_USER}/.local" \

--- a/images/github-runner-ci/build_files/packages.sh
+++ b/images/github-runner-ci/build_files/packages.sh
@@ -5,9 +5,12 @@ set -eoux pipefail
 # The small set of broadly useful shell/system tools for CI job containers.
 PACKAGES=(
     "bash"
+    "bubblewrap"
     "ca-certificates"
+    "file"
     "findutils"
     "jq"
+    "procps-ng"
     "ripgrep"
     "shadow-utils"
     "ShellCheck"
@@ -18,7 +21,14 @@ PACKAGES=(
 )
 
 dnf upgrade -y
+
+# Homebrew-on-Linux needs a build toolchain for formulae that compile from source.
+dnf group install \
+    -y \
+    development-tools
 dnf install \
     --setopt=install_weak_deps=False \
     -y \
     "${PACKAGES[@]}"
+
+/ctx/packages/homebrew.sh

--- a/images/github-runner-ci/build_files/packages/homebrew.sh
+++ b/images/github-runner-ci/build_files/packages/homebrew.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RUNNER_USER="${RUNNER_USER:-runner}"
+HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
+HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
+if [[ "$(id -u)" -eq 0 ]]; then
+    exec runuser -u "${RUNNER_USER}" -- env \
+        HOME="/home/${RUNNER_USER}" \
+        HOMEBREW_CELLAR="${HOMEBREW_PREFIX}/Cellar" \
+        HOMEBREW_NO_ANALYTICS="1" \
+        HOMEBREW_NO_AUTO_UPDATE="1" \
+        HOMEBREW_NO_ENV_HINTS="1" \
+        HOMEBREW_PREFIX="${HOMEBREW_PREFIX}" \
+        HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew" \
+        LOGNAME="${RUNNER_USER}" \
+        PATH="${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:${PATH}" \
+        USER="${RUNNER_USER}" \
+        "$0"
+fi
+
+installer="$(mktemp --tmpdir homebrew-install.XXXXXX.sh)"
+
+curl \
+    --fail \
+    --location \
+    --show-error \
+    --silent \
+    "${HOMEBREW_INSTALL_URL}" \
+    --output "${installer}"
+chmod 0755 "${installer}"
+
+CI=1 NONINTERACTIVE=1 /bin/bash "${installer}"
+
+cd "${HOME}"
+
+"${HOMEBREW_PREFIX}/bin/brew" analytics off
+"${HOMEBREW_PREFIX}/bin/brew" --version


### PR DESCRIPTION
## Summary
- install Homebrew into the github-runner-ci image under `/home/linuxbrew/.linuxbrew`
- keep the installation owned by the `runner` user so job containers can install packages at runtime
- extend the image workflow test to run `brew install hello` and execute `hello --version`

## Validation
- `devcontainer exec --workspace-folder . just check-format`
- `devcontainer exec --workspace-folder . shellcheck images/github-runner-ci/build_files/build.sh images/github-runner-ci/build_files/create-runner-user.sh images/github-runner-ci/build_files/packages.sh images/github-runner-ci/build_files/packages/homebrew.sh`
- `devcontainer exec --workspace-folder . hadolint images/github-runner-ci/Containerfile`
- `docker build --progress=plain -t github-runner-ci:brew-review -f images/github-runner-ci/Containerfile images/github-runner-ci`
- `docker run --rm github-runner-ci:brew-review bash -lc 'set -euo pipefail; test "$(id -u):$(id -g)" = "1001:1001"; test "$HOME" = "/home/runner"; brew --version; brew install hello; brew list --versions hello; hello --version'`